### PR TITLE
Works interactions

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -354,6 +354,7 @@ My works section
   width: 100%;
   scale: 1;
   transition: scale 500ms ease-in-out;
+  cursor: pointer;
 }
 
 .card__image:hover {

--- a/js/works.js
+++ b/js/works.js
@@ -92,8 +92,10 @@ const createWorkHTML = (work) => {
         <button class="button works__button">See project</button>
     </div>
   `;
-  const btnWorks = workCnt.querySelector('.works__button');
-  btnWorks.addEventListener('click', () => showWorksInfo(work));
+  const btnWork = workCnt.querySelector('.works__button');
+  const imgWork = workCnt.querySelector('figure');
+  btnWork.addEventListener('click', () => showWorksInfo(work));
+  imgWork.addEventListener('click', () => showWorksInfo(work));
   return workCnt;
 };
 

--- a/js/works.js
+++ b/js/works.js
@@ -1,6 +1,12 @@
 const popup = document.getElementById('popup');
 const btnClosePopup = document.getElementById('btnClosePopup');
 
+popup.addEventListener('click', (e) => {
+  if (e.target.id === 'popup') {
+    popup.style.display = 'none';
+  }
+});
+
 btnClosePopup.addEventListener('click', () => {
   popup.style.display = 'none';
 });


### PR DESCRIPTION
Allow users to open project information by clicking not only on the "see project" button but also on the images of each project.
Allow users to close the popup by clicking outside of it when it is displaying.
Add a cursor pointer to images to make it clear that you can open the project info by clicking on the image. 